### PR TITLE
Use better ssh options for bastions

### DIFF
--- a/ssha/ssh.py
+++ b/ssha/ssh.py
@@ -5,13 +5,35 @@ import os
 from . import config
 
 
+def _format_command(command):
+    args = []
+    for arg in command:
+        if ' ' in arg:
+            args.append('"' + arg + '"')
+        else:
+            args.append(arg)
+    return ' '.join(args)
+
+
 def _get_address(instance):
-    hostname = instance.get('PublicIpAddress') or instance['PrivateIpAddress']
+
     username = config.get('ssh.username')
+
+    # Don't add the username to the address when it is the current user,
+    # because it would make no difference.
+    if username == os.environ.get('USER'):
+        username = None
+
+    hostname = _get_hostname(instance)
+
     if username:
         return username + '@' + hostname
     else:
         return hostname
+
+
+def _get_hostname(instance):
+    return instance.get('PublicIpAddress') or instance['PrivateIpAddress']
 
 
 def connect(instance, bastion):
@@ -23,13 +45,18 @@ def connect(instance, bastion):
 
     identity_file = config.get('ssh.identity_file')
     if identity_file:
-        command += ['-i', identity_file]
+        # Don't add to the command when using the default identity,
+        # because it would make no difference.
+        if identity_file not in ('~/.ssh/id_dsa.pub', '~/.ssh/id_rsa.pub'):
+            command += ['-i', identity_file]
 
     if bastion:
-        command += ['-A', '-t', _get_address(bastion), 'ssh']
+        config.add('bastion.address', _get_address(bastion))
+        proxy_command = config.get('ssh.proxy_command')
+        command += ['-o', 'ProxyCommand={}'.format(proxy_command)]
 
     command += [_get_address(instance)]
 
-    print('[ssha] running {}'.format(' '.join(command)))
+    print('[ssha] running {}'.format(_format_command(command)))
 
     os.execlp('ssh', *command)


### PR DESCRIPTION
As discussed in #16 this now builds an SSH command that looks more like:

`ssh -o ProxyCommand="ssh -W %h:%p <jumphost>" <target>`

This can be customised in the settings file, like so:

```
[ssh]
proxy_command = "ssh -W %h:%p ${bastion.address}"
```

The above shows the default value. This setting doesn't need to be defined if the default value is suitable.