### PR TITLE
Require botocore version with SSM pagination

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'bin/ssha',
     ),
     install_requires=(
+        'botocore>=1.5.8',
         'boto3',
         'boto3-session-cache',
         'pyhcl',


### PR DESCRIPTION
I think they introduced it here. I had the version before it installed and it didn't work, but now it does.