### PR TITLE
Add user specific config file support for overriding project settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,24 @@ iam group developers {
 }
 ```
 
+## User config file
+
+For certain specific settings like the path to the public key to copy to instances you can use the user configuration file.
+
+The user configuration file can be created at the following paths:
+
+### Linux and Mac
+
+```
+~/.config/ssha/config
+```
+
+### Windows
+
+```
+%LOCALAPPDATA%\ssha\config
+```
+
 ## Contributing
 
 If you have an idea for a new feature, please submit an issue first to confirm whether a pull request would be accepted.


### PR DESCRIPTION
Adds a user specific config file so that you can override settings that are in the per project config files like the path to the SSH public key that SSHA should send to the server.

This is one of the parts of SSHA that is preventing it from being portable to Windows (I have created code to handle a user config file for Windows at %LOCALAPPDATA\ssha\config.

I also rewrote a few lines to make them fit the PEP-8 line length limit.
