### PR TITLE
Fix parsing version

### DIFF
--- a/ssha/settings.py
+++ b/ssha/settings.py
@@ -25,7 +25,7 @@ operators = {
 
 pattern = re.compile(
     r'\s*'
-    r'(?P<operator>[<=>!]{,2})?\s*'
+    r'(?P<operator>[<=>!]{1,2})?\s*'
     r'(?P<version>.+)\s*'
 )
 


### PR DESCRIPTION
ssha cannot parse `version = "1.2.3"` as the regex matches as `operator=''` instead of `operator=None`.