### PR TITLE
Use Paramiko to parse SSH config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'botocore>=1.5.8',
         'boto3',
         'boto3-session-cache',
+        'paramiko',
         'pyhcl',
     ),
 )


### PR DESCRIPTION
Because older versions of SSH don't have the -G option.

Resolves #55 