### PR TITLE
Fix username

### DIFF
--- a/ssha/config.py
+++ b/ssha/config.py
@@ -161,9 +161,9 @@ def load(name):
 
     # Default to SSH's default user.
     if not _get('ssh.username'):
-        for user in _get_ssh_config('user'):
+        user = _get_ssh_config('user')
+        if user:
             add('ssh.username', user)
-            break
 
     if _get('bastion') and not _get('ssh.proxy_command'):
         from . import ssh


### PR DESCRIPTION
It was previously returning a list of users but when switching to Paramiko for SSH config parsing, it changed to a single value.

This change stops it from logging in as `r@hostname` rather than `ray@hostname`. It "worked" before because strings are iterable, and it would just use the first character.