### PR TITLE
Python2: Fix possible UnicodeEncodeError when print

### DIFF
--- a/ssha/aws.py
+++ b/ssha/aws.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from functools import wraps
 
@@ -24,7 +25,7 @@ def retry(attempts=3):
                     return func(*args, **kwargs)
                 except (ClientError, ParamValidationError) as error:
                     if tries > 0:
-                        print(error)
+                        print('[ssha] {}'.format(error))
                     else:
                         raise
         return wrapped

--- a/ssha/config.py
+++ b/ssha/config.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import copy
 import os
 import re

--- a/ssha/settings.py
+++ b/ssha/settings.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import copy
 import hcl

--- a/ssha/ssh.py
+++ b/ssha/ssh.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import errno
 import os

--- a/ssha/ssm.py
+++ b/ssha/ssm.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import re
 import time


### PR DESCRIPTION
Resolve https://github.com/claranet/ssha/issues/59

Also updated other places where the `format` method is used as could cause an error.