### PR TITLE
Allow wildcards on config names

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Blocks can be updated per config.
 ```js
 ssha {
   name = "my-project"
-  configs = ["dev", "stage", "prod"]
+  configs = ["dev-nonprod", "stage-nonprod", "prod"]
 }
 
 /*
@@ -225,6 +225,14 @@ config prod {
   aws {
     profile_name = "my-project-prod"
   }
+}
+
+/*
+Wildcard characters can be used to match multiple configs.
+Python's fnmatch is used for pattern matching.
+*/
+config "*-nonprod" {
+  ...
 }
 ```
 

--- a/ssha/config.py
+++ b/ssha/config.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import tempfile
 
+from fnmatch import fnmatch
 from paramiko.config import SSHConfig
 
 from . import errors, settings
@@ -150,8 +151,9 @@ def load(name):
     if name:
         if name not in names():
             errors.string_exit('config {} not found in .ssha file'.format(name))
-        if name in config_specific_settings:
-            update(config_specific_settings[name])
+        for config_name in config_specific_settings:
+            if fnmatch(name, config_name):
+                update(config_specific_settings[config_name])
         add('config.name', name)
 
     iam_group_specific_settings = get('iam.group')
@@ -205,6 +207,12 @@ def load(name):
 def names():
     ssha_settings = settings.all().get('ssha') or {}
     return ssha_settings.get('configs') or []
+
+
+def reset():
+    _config.clear()
+    _ssh_config.clear()
+    _tempfiles.clear()
 
 
 def update(data):

--- a/ssha/settings.py
+++ b/ssha/settings.py
@@ -93,7 +93,7 @@ def all():
 def load(**defaults):
     if defaults.get('verbose'):
         print('[ssha] finding settings file')
-    _settings.update(defaults)
+    update(defaults)
 
     settings_path = defaults.get('settings_path')
     path = _find_settings_path(settings_path)
@@ -102,4 +102,12 @@ def load(**defaults):
         print('[ssha] loading {}'.format(path))
     data = _load(path)
     _validate_version(data)
+    update(data)
+
+
+def reset():
+    _settings.clear()
+
+
+def update(data):
     _settings.update(data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,14 @@
 import unittest
 
-from ssha import config
+from ssha import config, settings
 
 
 class TestConfig(unittest.TestCase):
 
     def setUp(self):
-        # Reset the global config before each test.
-        config._config = {}
+        # Reset the global settings and config objects before each test.
+        settings.reset()
+        config.reset()
 
     def test_add(self):
         # Add a simple top-level value.
@@ -19,3 +20,35 @@ class TestConfig(unittest.TestCase):
         config.add('three.four', 'five')
         self.assertEqual(config.get('three.four'), 'five')
         self.assertDictEqual(config.get('three'), {'four': 'five'})
+
+    def test_config_names(self):
+        # Add settings with regular and wildcard config names.
+        settings.update({
+            'ssha': {
+                'configs': ['test-nonprod', 'test-prod'],
+            },
+            'config': {
+                'test-nonprod': {
+                    'value1': 'a',
+                },
+                '*-nonprod': {
+                    'value2': 'b',
+                },
+                '*-prod': {
+                    'value3': 'c',
+                },
+            },
+        })
+
+        # The test-nonprod config should match 2 configs.
+        config.load('test-nonprod')
+        self.assertEqual(config.get('value1'), 'a')
+        self.assertEqual(config.get('value2'), 'b')
+        self.assertEqual(config.get('value3'), None)
+
+        # The test-prod config should match 1 config.
+        config.reset()
+        config.load('test-prod')
+        self.assertEqual(config.get('value1'), None)
+        self.assertEqual(config.get('value2'), None)
+        self.assertEqual(config.get('value3'), 'c')


### PR DESCRIPTION
This allows things like: `config "*-nonprod" { ... }`