### PR TITLE
 Fix error caused by instances missing tags

### DIFF
--- a/ssha/ec2.py
+++ b/ssha/ec2.py
@@ -124,6 +124,5 @@ def label(instance):
         value = instance
         for key in field.split('.'):
             value = value.get(key)
-        if value:
-            result.append(value)
+        result.append(value or '')
     return result or [instance['InstanceId']]

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,9 +1,28 @@
 import unittest
 
-from ssha import ec2
+from ssha import config, ec2, settings
 
 
 class TestEC2(unittest.TestCase):
+
+    def setUp(self):
+        # Reset the global settings and config objects before each test.
+        settings.reset()
+        config.reset()
+
+    def test_label(self):
+        # Test that missing display fields result in blank strings.
+        config.add(
+            'display.fields',
+            ['InstanceId', 'Tags.Environment', 'Tags.Name'],
+        )
+        label = ec2.label({
+            'InstanceId': 'abc',
+            'Tags': {
+                'Name': 'xyz',
+            },
+        })
+        self.assertEqual(label, ['abc', '', 'xyz'])
 
     def test_rules_pass(self):
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py3,flake8
 
 [testenv]
+deps = paramiko
 commands = python -m unittest discover tests
 
 [testenv:flake8]


### PR DESCRIPTION
The column rendering code requires that all instance labels have the same number of elements.