### PR TITLE
Fix missing AgentVersion

### DIFF
--- a/ssha/ssm.py
+++ b/ssha/ssm.py
@@ -122,8 +122,12 @@ def session_manager_enabled(instance):
         return False
 
     # Check if agent is installed.
-    if not instance.get('AgentVersion'):
-        return False
+    ssm = aws.client('ssm')
+    instance_metadata = ssm.describe_instance_information(InstanceInformationFilterList=[{'key': 'InstanceIds', 'valueSet': [instance['InstanceId']]}])['InstanceInformationList']
+
+    if len(instance_metadata) != 0:
+        if not instance_metadata[0].get('AgentVersion'):
+            return False
 
     # Check if required plugin is installed.
     if os.system('which session-manager-plugin > /dev/null') != 0:


### PR DESCRIPTION
AgentVersion is no longer returned by the describe-instances EC2 API call and instead must be gathered by the SSM describe-instance-information API call.

Replacing the check of AgentVersion being within describe-instances with a check to within describe-instance-information's output.

Fixes #75